### PR TITLE
Update Jakarta Tags imports for EE11 features

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -2,7 +2,7 @@
 <!--
 
     Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2021-2022 Contributors to the Eclipse Foundation
+    Copyright (c) 2021-2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -204,6 +204,11 @@
                         <Specification-Vendor>${project.organization.name}</Specification-Vendor>
                         <Implementation-Vendor>${project.organization.name}</Implementation-Vendor>
                         <Implementation-Vendor-Id>org.glassfish</Implementation-Vendor-Id>
+                        <Import-Package>
+                            jakarta.el;version="[5.0,7)",
+                            jakarta.servlet.jsp;version="[3.1,5)",
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
                 <executions>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+    Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
     Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -235,6 +235,8 @@
                             !org.apache.xpath.res,
                             !java_cup.runtime,
                             !trax,
+                            jakarta.el;version="[5.0,7)",
+                            jakarta.servlet.jsp;version="[3.1,5)",
                             org.xml.sax.ext,
                             *
                         </Import-Package>


### PR DESCRIPTION
Details of the original request can be seen in this closed PR: https://github.com/jakartaee/tags/pull/253

Jakarta Tags is not updating for Jakarta EE11. Since Jakarta Tags is not updating it must continue to function with the Jakarta EE11 version of its dependencies.

The original API MANIFEST.MF imports looked like the following:

> Import-Package: jakarta.el;version="[5.0,6)",jakarta.servlet;version="[6
>  .0,7)",jakarta.servlet.http;version="[6.0,7)",jakarta.servlet.jsp;versi
>  on="[3.1,4)",jakarta.servlet.jsp.jstl.core,jakarta.servlet.jsp.tagext;v
>  ersion="[3.1,4)",javax.xml.parsers,org.xml.sax,org.xml.sax.helpers


After this change the API MANIFEST.MF imports look like this:

> Import-Package: jakarta.el;version="[5.0,7)",jakarta.servlet.jsp;version
>  ="[3.1,5)",jakarta.servlet;version="[6.0,7)",jakarta.servlet.http;versi
>  on="[6.0,7)",jakarta.servlet.jsp.jstl.core,jakarta.servlet.jsp.tagext;v
>  ersion="[3.1,4)",javax.xml.parsers,org.xml.sax,org.xml.sax.helpers

The original Implementation MANIFEST.MF imports looked like:

> Import-Package: jakarta.el;version="[5.0,6)",jakarta.servlet;version="[6
>  .0,7)",jakarta.servlet.http;version="[6.0,7)",jakarta.servlet.jsp;versi
>  on="[3.1,4)",jakarta.servlet.jsp.jstl.core;version="[3.0,4)",jakarta.se
>  rvlet.jsp.jstl.fmt;version="[3.0,4)",jakarta.servlet.jsp.jstl.sql;versi
>  on="[3.0,4)",jakarta.servlet.jsp.tagext;version="[3.1,4)",javax.naming,
>  javax.sql,javax.xml.namespace,javax.xml.parsers,javax.xml.transform,jav
>  ax.xml.transform.dom,javax.xml.transform.sax,javax.xml.transform.stream
>  ,javax.xml.xpath,org.apache.taglibs.standard.lang.jstl,org.apache.tagli
>  bs.standard.lang.jstl.parser,org.apache.taglibs.standard.lang.support,o
>  rg.apache.taglibs.standard.resources,org.apache.taglibs.standard.tag.co
>  mmon.core,org.apache.taglibs.standard.tag.common.fmt,org.apache.taglibs
>  .standard.tag.common.sql,org.apache.taglibs.standard.tag.common.xml,org
>  .apache.taglibs.standard.tag.el.core,org.w3c.dom,org.w3c.dom.traversal,
>  org.xml.sax,org.xml.sax.helpers,org.xml.sax.ext


After this change the Implementation MANIFEST.MF imports look like:

> 
> Import-Package: jakarta.el;version="[5.0,7)",jakarta.servlet.jsp;version
>  ="[3.1,5)",jakarta.servlet;version="[6.0,7)",jakarta.servlet.http;versi
>  on="[6.0,7)",jakarta.servlet.jsp.jstl.core;version="[3.0,4)",jakarta.se
>  rvlet.jsp.jstl.fmt;version="[3.0,4)",jakarta.servlet.jsp.jstl.sql;versi
>  on="[3.0,4)",jakarta.servlet.jsp.tagext;version="[3.1,4)",javax.naming,
>  javax.sql,javax.xml.namespace,javax.xml.parsers,javax.xml.transform,jav
>  ax.xml.transform.dom,javax.xml.transform.sax,javax.xml.transform.stream
>  ,javax.xml.xpath,org.apache.taglibs.standard.lang.jstl,org.apache.tagli
>  bs.standard.lang.jstl.parser,org.apache.taglibs.standard.lang.support,o
>  rg.apache.taglibs.standard.resources,org.apache.taglibs.standard.tag.co
>  mmon.core,org.apache.taglibs.standard.tag.common.fmt,org.apache.taglibs
>  .standard.tag.common.sql,org.apache.taglibs.standard.tag.common.xml,org
>  .apache.taglibs.standard.tag.el.core,org.w3c.dom,org.w3c.dom.traversal,
>  org.xml.sax,org.xml.sax.helpers,org.xml.sax.ext




