### PR TITLE
Prepare for 3.0.1 API release

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>jakarta.servlet.jsp.jstl</groupId>
     <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Jakarta Standard Tag Library API</name>


### PR DESCRIPTION
This is the work necessary to prepare for a 3.0.1 API release for Jakarta EE11. This release will include the expanded imports: https://github.com/jakartaee/tags/pull/254