### PR TITLE
Expand the import version range for `jakarta.servlet.jsp.tagext`

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -207,6 +207,7 @@
                         <Import-Package>
                             jakarta.el;version="[5.0,7)",
                             jakarta.servlet.jsp;version="[3.1,5)",
+                            jakarta.servlet.jsp.tagext;version="[3.1,5)",
                             *
                         </Import-Package>
                     </instructions>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -237,6 +237,7 @@
                             !trax,
                             jakarta.el;version="[5.0,7)",
                             jakarta.servlet.jsp;version="[3.1,5)",
+                            jakarta.servlet.jsp.tagext;version="[3.1,5)",
                             org.xml.sax.ext,
                             *
                         </Import-Package>


### PR DESCRIPTION
The original PR: https://github.com/jakartaee/tags/pull/254 missed the `jakarta.servlet.jsp.tagext` package in the 3.0.1 release. I am preparing this PR for a 3.0.2 release.

Although the IMPL isn't used in this branch, I want to bring the existing code up to date since the original PR was merged.